### PR TITLE
a callback *must* be called exactly once.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function LevelWriteStream(db) {
             }
 
             queue.push(chunk)
-            stream.on("_drain", callback)
+            stream.once("_drain", callback)
         }
 
         function drain() {


### PR DESCRIPTION
this was calling each callback many times.
Each even registered another listener, and all the listeners where called every time a write finished.
That broke the counter in end-stream, meaning that a write stream never emitted the finish event.

need this patch for an upcoming pr to sublevel-migrate
